### PR TITLE
feat: 이슈 목록 조회 API 구현

### DIFF
--- a/frontend/src/entities/issue/issue.ts
+++ b/frontend/src/entities/issue/issue.ts
@@ -1,0 +1,42 @@
+export interface Label {
+	id: number;
+	name: string;
+	color: string;
+}
+
+export interface Author {
+	id: number;
+	username: string;
+	imageUrl: string;
+}
+
+export interface Milestone {
+	id: number;
+	title: string;
+}
+
+export interface Issue {
+	id: number;
+	number?: number;
+	title: string;
+	labels: Label[];
+	author: Author;
+	milestone: Milestone | null;
+	createdAt: string;
+	updatedAt: string | null;
+	commentsCount: number;
+	open: boolean;
+}
+
+export interface IssueListData {
+	total: number;
+	page: number;
+	perPage: number;
+	issues: Issue[];
+}
+
+export interface ApiResponse<T, E = unknown> {
+	success: boolean;
+	data: T;
+	error: E | null;
+}

--- a/frontend/src/entities/issue/issueAPI.ts
+++ b/frontend/src/entities/issue/issueAPI.ts
@@ -1,0 +1,7 @@
+import { getJSON } from '@/shared/api/client';
+import type { ApiResponse, IssueListData } from './issue';
+
+export async function fetchIssues(): Promise<IssueListData> {
+	const res = await getJSON<ApiResponse<IssueListData>>('/api/issues');
+	return res.data;
+}

--- a/frontend/src/entities/issue/issueFixtures.ts
+++ b/frontend/src/entities/issue/issueFixtures.ts
@@ -1,0 +1,51 @@
+// src/entities/issue/issueFixtures.ts
+import type { ApiResponse, Issue, IssueListData } from './issue';
+
+const issues: Issue[] = [
+	{
+		id: 42,
+		number: 1234,
+		title: '버튼 클릭 시 모달이 열리지 않는 문제',
+		labels: [
+			{ id: 1, name: 'bug', color: '#d73a4a' },
+			{ id: 3, name: 'ui', color: '#1d76db' },
+		],
+		author: {
+			id: 7,
+			username: 'alice',
+			imageUrl: 'https://example.com/avatar/alice.png',
+		},
+		milestone: { id: 2, title: 'v1.0 릴리즈' },
+		createdAt: '2025-05-01T09:15:00Z',
+		updatedAt: '2025-05-10T10:11:00Z',
+		commentsCount: 4,
+		open: true,
+	},
+	{
+		id: 43,
+		number: 1235,
+		title: '로그인 API 응답 속도 개선 요청',
+		labels: [{ id: 2, name: 'enhancement', color: '#a2eeef' }],
+		author: {
+			id: 9,
+			username: 'bob',
+			imageUrl: 'https://example.com/avatar/bob.png',
+		},
+		milestone: null,
+		createdAt: '2025-04-28T14:03:00Z',
+		updatedAt: null,
+		commentsCount: 2,
+		open: false,
+	},
+];
+
+export const mockIssueListResponse: ApiResponse<IssueListData> = {
+	success: true,
+	data: {
+		total: issues.length,
+		page: 1,
+		perPage: issues.length,
+		issues,
+	},
+	error: null,
+};

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -1,0 +1,55 @@
+const BASE_URL = import.meta.env.VITE_API_BASE_URL; // 예: "https://api.example.com"
+const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true'; // .env에서 VITE_USE_MOCK=true로 설정 시 모킹 활성화
+
+/**
+ * 실제 서버와 통신하는 getJSON 함수
+ */
+async function realGetJSON<T>(path: string): Promise<T> {
+	const res = await fetch(`${BASE_URL}${path}`, {
+		method: 'GET',
+		headers: { Accept: 'application/json' },
+	});
+
+	/**
+	 * 응답 상태가 200~299가 아닐 경우 Error를 던집니다.
+	 * 호출자는 이 에러를 catch하여 토스트 메시지 표시, 재시도 로직 실행,
+	 * 에러 페이지 이동 등 적절한 처리를 수행해야 합니다.
+	 */
+	if (!res.ok) {
+		throw new Error(`API 요청 실패: ${res.status} ${res.statusText}`);
+	}
+
+	// 성공 응답일 경우 JSON 본문을 파싱하여 반환합니다.
+	return res.json();
+}
+
+/**
+ * 모의 데이터를 반환하는 getJSON 함수
+ * path에 따라 필요한 mock 데이터를 분기하여 반환하세요.
+ */
+async function mockGetJSON<T>(path: string): Promise<T> {
+	// 예시: '/api/issues' 요청 시 issueFixtures에서 정의한 mock 데이터를 반환
+	if (path === '/api/issues') {
+		const { mockIssueListResponse } = await import(
+			'@/entities/issue/issueFixtures'
+		);
+		// 타입 단언을 통해 T 형태로 반환
+		return mockIssueListResponse as unknown as T;
+	}
+
+	// 정의되지 않은 경로는 에러 처리
+	throw new Error(`알 수 없는 mock 경로: ${path}`);
+}
+
+/**
+ * 주어진 경로(path)에 GET 요청을 보내고, JSON 응답을 파싱하여 반환합니다.
+ *
+ * @template T - 반환될 JSON 데이터의 타입을 지정합니다.
+ * @param path - API 엔드포인트 경로 (예: "/api/issues").
+ * @returns 파싱된 JSON 데이터(T 타입)의 Promise.
+ *
+ * @throws Error if HTTP 상태 코드가 200~299 범위가 아닐 경우 Error를 던집니다.
+ *
+ * 실제 통신 또는 mock 중 하나를 자동으로 선택하여 사용합니다.
+ */
+export const getJSON = USE_MOCK ? mockGetJSON : realGetJSON;


### PR DESCRIPTION
## 📝 작업 내용
- 이슈 목록을 조회하는 API를 구현했다.
  - npm run dev(or vite) 로 실행 시 .env.development 가 적용되어 mock 모드,
  - npm run build 후 배포된 환경에선 .env.production 으로 실제 API 호출 모드가 켜짐
- 환경 설정 방법
```env
// .env.development
VITE_USE_MOCK=true
```
```env
// .env.production
VITE_USE_MOCK=false
```
## 🤔 고민사항
- 테스트 환경과 실제 배포 환경에서 fetch를 어떻게 자동으로 구분할지 고민했고, 해결 방안으로 환경 설정 방법을 적용했다.
