### PR TITLE
[CS-78] POST /api/issues 컨트롤러 작성

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/team5/issue_tracker/common/aop/LoggingAspect.java
+++ b/backend/src/main/java/com/team5/issue_tracker/common/aop/LoggingAspect.java
@@ -1,0 +1,52 @@
+package com.team5.issue_tracker.common.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.*;
+import org.aspectj.lang.annotation.*;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAspect {
+
+  // 컨트롤러와 서비스 레이어 전체 대상
+  @Pointcut("execution(* com.team5.issue_tracker..controller..*(..)) || execution(* com.team5.issue_tracker..service..*(..))")
+  public void applicationLayer() {}
+
+  // 메서드 실행 전 요청 로그
+  @Before("applicationLayer()")
+  public void logRequest(JoinPoint joinPoint) {
+    String methodName = joinPoint.getSignature().toShortString();
+    Object[] args = joinPoint.getArgs();
+    log.info("▶️요청 - {} | args = {}", methodName, args);
+  }
+
+  // 메서드 정상 리턴 후 응답 로그
+  @AfterReturning(pointcut = "applicationLayer()", returning = "result")
+  public void logResponse(JoinPoint joinPoint, Object result) {
+    String methodName = joinPoint.getSignature().toShortString();
+    log.info("✅응답 - {} | result = {}", methodName, result);
+  }
+
+  // 예외 발생 시 로그
+  @AfterThrowing(pointcut = "applicationLayer()", throwing = "e")
+  public void logException(JoinPoint joinPoint, Throwable e) {
+    String methodName = joinPoint.getSignature().toShortString();
+    log.error("❌예외 - {} | message = {}", methodName, e.getMessage(), e);
+  }
+
+  // 실행 시간 측정 로그
+  @Around("applicationLayer()")
+  public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+    long start = System.currentTimeMillis();
+
+    Object result = joinPoint.proceed();  // 실제 메서드 실행
+
+    long end = System.currentTimeMillis();
+    String methodName = joinPoint.getSignature().toShortString();
+    log.info("⏱️실행 시간 - {} | {} ms", methodName, (end - start));
+
+    return result;
+  }
+}

--- a/backend/src/main/java/com/team5/issue_tracker/issue/controller/IssueController.java
+++ b/backend/src/main/java/com/team5/issue_tracker/issue/controller/IssueController.java
@@ -2,14 +2,18 @@ package com.team5.issue_tracker.issue.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.team5.issue_tracker.common.dto.ApiResponse;
+import com.team5.issue_tracker.issue.dto.request.IssueCreateRequest;
 import com.team5.issue_tracker.issue.dto.response.IssuePageResponse;
 import com.team5.issue_tracker.issue.query.IssueQueryService;
 import com.team5.issue_tracker.issue.service.IssueService;
 import com.team5.issue_tracker.user.dto.UserPageResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -25,6 +29,14 @@ public class IssueController {
   public ResponseEntity<ApiResponse<IssuePageResponse>> getAllIssues() {
     log.info("GET /api/issues 요청");
     return ResponseEntity.ok(ApiResponse.success(issueQueryService.getIssuePage()));
+  }
+
+  @PostMapping()
+  public ResponseEntity<ApiResponse<Long>> createIssue(
+      @Valid @RequestBody IssueCreateRequest request
+  ) {
+    log.info("GET /api/issues 요청");
+    return ResponseEntity.ok(ApiResponse.success(issueService.createIssue(request)));
   }
 
   @GetMapping("/authors")

--- a/backend/src/main/java/com/team5/issue_tracker/issue/domain/Issue.java
+++ b/backend/src/main/java/com/team5/issue_tracker/issue/domain/Issue.java
@@ -1,31 +1,54 @@
 package com.team5.issue_tracker.issue.domain;
 
 import java.time.LocalDateTime;
+
 import lombok.Getter;
+
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
 
 @Getter
 public class Issue {
-    @Id
-    private Long id;
+  @Id
+  private Long id;
 
-    private final String title;
-    private final String body;
-    private final String imageUrl;
-    private final Long userId;
-    private final Long milestoneId;
-    private final boolean isOpen;
+  private String title;
+  private String body;
+  private Long milestoneId;
+  private Boolean isOpen;
 
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+  private final Long userId;
+  //todo: 글로벌 서비스를 위한 자료형 변경
+  private final LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
 
-  public Issue(String title, String body, String imageUrl,
-      Long userId, Long milestoneId, boolean isOpen) {
+  public Issue(String title, String body, Long userId, Long milestoneId, boolean isOpen) {
     this.title = title;
     this.body = body;
-    this.imageUrl = imageUrl;
     this.userId = userId;
     this.milestoneId = milestoneId;
     this.isOpen = isOpen;
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  @PersistenceConstructor
+  public Issue(String title, String body, Long userId, Long milestoneId, boolean isOpen,
+      LocalDateTime createdAt, LocalDateTime updatedAt) {
+    this.title = title;
+    this.body = body;
+    this.userId = userId;
+    this.milestoneId = milestoneId;
+    this.isOpen = isOpen;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public void update(String title, String body, Long milestoneId, boolean isOpen) {
+    this.title = title;
+    this.body = body;
+    this.milestoneId = milestoneId;
+    this.isOpen = isOpen;
+    this.updatedAt = LocalDateTime.now();
   }
 }

--- a/backend/src/main/java/com/team5/issue_tracker/issue/domain/IssueAssignee.java
+++ b/backend/src/main/java/com/team5/issue_tracker/issue/domain/IssueAssignee.java
@@ -1,0 +1,22 @@
+package com.team5.issue_tracker.issue.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import lombok.Getter;
+
+@Getter
+@Table("issue_assignee")
+public class IssueAssignee {
+
+  @Id
+  private Long id;
+
+  private final Long issueId;
+  private final Long assigneeId; //assignee id를 final로 한 이유는 변경시 삭제후 삽입방식으로 하려고 합니다.
+
+  public IssueAssignee(Long issueId, Long assigneeId) {
+    this.issueId = issueId;
+    this.assigneeId = assigneeId;
+  }
+}

--- a/backend/src/main/java/com/team5/issue_tracker/issue/domain/IssueLabel.java
+++ b/backend/src/main/java/com/team5/issue_tracker/issue/domain/IssueLabel.java
@@ -1,0 +1,22 @@
+package com.team5.issue_tracker.issue.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import lombok.Getter;
+
+@Getter
+@Table("issue_label")
+public class IssueLabel {
+
+  @Id
+  private Long id;
+
+  private final Long issueId;
+  private final Long labelId;
+
+  public IssueLabel(Long issueId, Long labelId) {
+    this.issueId = issueId;
+    this.labelId = labelId;
+  }
+}

--- a/backend/src/main/java/com/team5/issue_tracker/issue/dto/request/IssueCreateRequest.java
+++ b/backend/src/main/java/com/team5/issue_tracker/issue/dto/request/IssueCreateRequest.java
@@ -2,17 +2,29 @@ package com.team5.issue_tracker.issue.dto.request;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class IssueCreateRequest {
+
+  @NotBlank(message = "제목을 작성해주세요.")
   private String title;
+
+  @NotBlank(message = "본문을 작성해주세요.")
   private String body;
-  private Long assignee;
-  private List<Long> labels;
-  private Long milestone;
+
+  @NotNull(message = "담당자를 넣어주세요.")
+  private List<Long> assigneeIds;
+
+  @NotNull(message = "라벨을 넣어주세요.")
+  private List<Long> labelIds;
+  private Long milestoneId;
 }

--- a/backend/src/main/java/com/team5/issue_tracker/issue/repository/IssueAssigneeRepository.java
+++ b/backend/src/main/java/com/team5/issue_tracker/issue/repository/IssueAssigneeRepository.java
@@ -1,0 +1,10 @@
+package com.team5.issue_tracker.issue.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+import com.team5.issue_tracker.issue.domain.IssueAssignee;
+
+public interface IssueAssigneeRepository extends CrudRepository<IssueAssignee, Long> {
+  List<IssueAssignee> findByIssueId(Long issueId);
+}

--- a/backend/src/main/java/com/team5/issue_tracker/issue/repository/IssueLabelRepository.java
+++ b/backend/src/main/java/com/team5/issue_tracker/issue/repository/IssueLabelRepository.java
@@ -1,0 +1,10 @@
+package com.team5.issue_tracker.issue.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+import com.team5.issue_tracker.issue.domain.IssueLabel;
+
+public interface IssueLabelRepository extends CrudRepository<IssueLabel, Long> {
+  List<IssueLabel> findByIssueId(Long issueId);
+}

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -54,17 +54,19 @@ CREATE TABLE label
 );
 CREATE TABLE issue_label
 (
+    id       BIGINT AUTO_INCREMENT PRIMARY KEY,
     issue_id BIGINT NOT NULL,
     label_id BIGINT NOT NULL,
-    PRIMARY KEY (issue_id, label_id),
+    UNIQUE (issue_id, label_id),
     FOREIGN KEY (issue_id) REFERENCES issue (id) ON DELETE CASCADE,
     FOREIGN KEY (label_id) REFERENCES label (id) ON DELETE CASCADE
 );
 CREATE TABLE issue_assignee
 (
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
     issue_id    BIGINT NOT NULL,
     assignee_id BIGINT NOT NULL,
-    PRIMARY KEY (issue_id, assignee_id),
+    UNIQUE (issue_id, assignee_id),
     FOREIGN KEY (issue_id) REFERENCES issue (id) ON DELETE CASCADE,
     FOREIGN KEY (assignee_id) REFERENCES user (id) ON DELETE CASCADE
 );

--- a/backend/src/test/java/com/team5/issue_tracker/issue/service/IssueServiceTest.java
+++ b/backend/src/test/java/com/team5/issue_tracker/issue/service/IssueServiceTest.java
@@ -2,124 +2,59 @@ package com.team5.issue_tracker.issue.service;
 
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 import com.team5.issue_tracker.issue.domain.Issue;
+import com.team5.issue_tracker.issue.domain.IssueAssignee;
+import com.team5.issue_tracker.issue.domain.IssueLabel;
 import com.team5.issue_tracker.issue.dto.request.IssueCreateRequest;
+import com.team5.issue_tracker.issue.repository.IssueAssigneeRepository;
+import com.team5.issue_tracker.issue.repository.IssueLabelRepository;
 import com.team5.issue_tracker.issue.repository.IssueRepository;
-import com.team5.issue_tracker.user.service.UserService;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@Transactional
 public class IssueServiceTest {
+  @Autowired
+  private IssueService issueService;
 
-  @InjectMocks
-  private IssueService issueService; // 실제로 테스트를 진행하는 객체에는 Inject를 사용
-
-  @Mock
+  @Autowired
   private IssueRepository issueRepository;
 
-  @Mock
-  private UserService userService;
+  @Autowired
+  private IssueLabelRepository issueLabelRepository;
+
+  @Autowired
+  private IssueAssigneeRepository issueAssigneeRepository;
 
   @Test
-  @DisplayName("정상 요청에 이슈가 생성되어야 한다.")
-  void createIssue_success_정상_요청() {
+  @DisplayName("정상 요청 시 이슈와 라벨/담당자가 저장된다")
+  void createIssue_sccess() {
     // given
     IssueCreateRequest request = new IssueCreateRequest(
-        "hello World",
-        "java",
-        1L,
+        "왕이 넘어지면?",
+        "King Kong ㅋㅋㅋ",
         List.of(1L, 2L),
-        null
+        List.of(1L, 2L),
+        1L
     );
-
-    Long userId = 1L;
-
-    when(issueRepository.save(any(Issue.class)))
-        .thenAnswer(invocation -> invocation.getArgument(0));
 
     // when
-    Issue saved = issueService.createIssue(request, userId);
+    Long issueId = issueService.createIssue(request);
 
     // then
-    assertThat(saved).isNotNull();
-    verify(issueRepository).save(any(Issue.class));
+    Issue issue = issueRepository.findById(issueId).orElseThrow();
+    assertThat(issue.getTitle()).isEqualTo("왕이 넘어지면?");
+
+    List<IssueLabel> labels = issueLabelRepository.findByIssueId(issueId);
+    assertThat(labels).hasSize(2);
+
+    List<IssueAssignee> assignees = issueAssigneeRepository.findByIssueId(issueId);
+    assertThat(assignees).hasSize(2);
   }
-
-  @Test
-  @DisplayName("작성자가 존재하지 않으면 예외가 발생한다")
-  void createIssue_fail_존재하지_않는_사용자_요청() {
-    // given
-    IssueCreateRequest request = new IssueCreateRequest(
-        "hello World",
-        "java",
-        1L,
-        List.of(1L, 2L),
-        null
-    );
-
-    Long userId = 9999L; // 존재하지 않는 ID
-
-    when(userService.existsById(userId)).thenReturn(false);
-
-    //when & then
-    assertThatThrownBy(() -> issueService.createIssue(request, userId))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("작성자가 존재하지 않습니다.");
-  }
-
-  @Test
-  @DisplayName("제목이 null이면 예외가 발생한다")
-  void createIssue_fail_제목이_null() {
-    //given
-    IssueCreateRequest request = new IssueCreateRequest(
-        null,
-        "java",
-        1L,
-        List.of(1L, 2L),
-        null
-    );
-
-    Long userId = 1L;
-
-    when(userService.existsById(userId)).thenReturn(true);
-
-    //when&then
-    assertThatThrownBy(() -> issueService.createIssue(request, userId))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("제목을 작성해주세요.");
-  }
-
-  @Test
-  @DisplayName("본문이 null이면 예외가 발생한다")
-  void createIssue_fail_본문이_null() {
-    //given
-    IssueCreateRequest request = new IssueCreateRequest(
-        "hello World",
-        " ", // null일 때도 가능
-        1L,
-        List.of(1L, 2L),
-        null
-    );
-
-    Long userId = 1L;
-
-    when(userService.existsById(userId)).thenReturn(true);
-
-    //when&then
-    assertThatThrownBy(() -> issueService.createIssue(request, userId))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("본문을 작성해주세요.");
-  }
-
 }


### PR DESCRIPTION
## 📝 작업 내용
### 기능 개발
- [CS-78] 이슈 작성 POST 요청 구현
  - `@Valid` 를 활용한 요청 검증 처리
  - 테스트 코드 수정: 서비스 단 검증 로직 제거
- AOP 기반 로깅 기능 추가
- 이슈-라벨, 이슈-담당자(N:M) 도메인 및 Repository 구현
- 이슈 생성 시 라벨/담당자 저장 로직 메서드 분리
  - DTO에서 @NotNull로 유효성 검증
  - 서비스에서 개별 저장 메서드 (saveIssueLabels, saveIssueAssignees)로 분리

---

### 리팩토링
- issue 테이블에서 `image_url` 속성 제거
  - 기존에는 첨부 이미지를 1개로 제한했으나 추후 확장 예정
- UserService 내부에 작성자 존재 여부 확인 로직 추가
  - 현재 구조 상 IssueService에서만 참조하므로 순환 참조 문제는 발생하지 않음
- 도메인 리팩토링
  - 변경 가능한 필드/불변 필드 재설정
  - N:M 관계 테이블(IssueLabel, IssueAssignee)은 추후 수정 시 삭제-재생성할 예정
- Spring Data JDBC를 위한 변경
  - `@PersistenceConstructor` 로 DB 조회용 생성자 정의
  - 복합 키를 지원하지 않기 때문에 N:M 테이블에 id 필드 추가 및 (issue_id, assignee_id)에 `UNIQUE` 제약 추가

---

###  테스트
- 통합 테스트 추가
  - 이슈 생성 시 라벨 및 담당자가 함께 저장되는지 검증

---

## 🤔 고민사항
- @PersistenceConstructor의 추가로 생성자가 2개가 만들어지는 구조에 대해서 고민을 했습니다.


[CS-78]: https://jqk1797.atlassian.net/browse/CS-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ